### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -6,7 +6,7 @@
       <div class="navbar-menu has-text-centered is-active">
           <div class="navbar-end is-centered">
               {{ range .Site.Params.social }}
-                <a href="{{ .url | absURL }}">
+                <a href="{{ .url | absURL }}" rel="me">
                   <span class="icon">
                     <i class="{{ .fa_icon }}"></i>
                   </span>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.